### PR TITLE
Redesign clickhouse query routine

### DIFF
--- a/storages/base/base.go
+++ b/storages/base/base.go
@@ -31,7 +31,7 @@ import (
 type Storage interface {
 	// Read runs queries in the storage and returns the same amount of matrixes.
 	// Event if they are empty, they must be present in the returned slice.
-	Read(context.Context, []Query) (*prompb.ReadResponse, error)
+	Read(context.Context, []Query, *prompb.ReadHints) (*prompb.ReadResponse, error)
 
 	// Write puts data into storage.
 	Write(context.Context, *prompb.WriteRequest) error

--- a/storages/blackhole/blackhole.go
+++ b/storages/blackhole/blackhole.go
@@ -54,7 +54,7 @@ func (b *blackhole) Collect(c chan<- prometheus.Metric) {
 	b.mDummy.Collect(c)
 }
 
-func (b *blackhole) Read(ctx context.Context, queries []base.Query) (*prompb.ReadResponse, error) {
+func (b *blackhole) Read(ctx context.Context, queries []base.Query, hints *prompb.ReadHints) (*prompb.ReadResponse, error) {
 	res := &prompb.ReadResponse{
 		Results: make([]*prompb.QueryResult, len(queries)),
 	}

--- a/storages/memory/memory.go
+++ b/storages/memory/memory.go
@@ -62,7 +62,7 @@ func (m *memory) Collect(c chan<- prometheus.Metric) {
 	m.mDummy.Collect(c)
 }
 
-func (m *memory) Read(ctx context.Context, queries []base.Query) (*prompb.ReadResponse, error) {
+func (m *memory) Read(ctx context.Context, queries []base.Query, hints *prompb.ReadHints) (*prompb.ReadResponse, error) {
 	m.rw.RLock()
 	defer m.rw.RUnlock()
 


### PR DESCRIPTION
This PR moves PromHouse from loading time_series to in-memory array and running in-memory scan over milions of records on each query.
Also enables prometheus Hints for resolution in samples.

TODO:
add full support for prometheus regex queries.

@vinted/sre, @ernestas-vinted 